### PR TITLE
Fix the layout for mobile devices

### DIFF
--- a/sana_builder/webapp/templates/webapp/index.html
+++ b/sana_builder/webapp/templates/webapp/index.html
@@ -4,6 +4,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
 
     {% if debug %}


### PR DESCRIPTION
Turns out Bootstrap won't use the mobile styles unless this tag is specified.

http://getbootstrap.com/css/#overview-mobile
