### PR TITLE
Update mixlib gem to fix bundler errors

### DIFF
--- a/chef/Gemfile.lock
+++ b/chef/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.1)
     net-ssh (2.9.1)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)


### PR DESCRIPTION
As per https://www.chef.io/blog/2014/12/02/postmortem-ohai-mixlib-shellout-gem-release-issues/