### PR TITLE
Modified CLOC script to ignore temp directories

### DIFF
--- a/scripts/cloc.sh
+++ b/scripts/cloc.sh
@@ -3,6 +3,7 @@
 cloc \
     --exclude-list-file=cloc-ignore.txt \
     --read-lang-def=cloc-definitions.txt \
+    --exclude-dir=tmp,dist,node_modules,bower_components \
     \
     ../mockups \
     ../docs \


### PR DESCRIPTION
```
$ ./cloc.sh 
      98 text files.
      94 unique files.                              
   36350 files ignored.

http://cloc.sourceforge.net v 1.60  T=2.59 s (27.8 files/s, 1124.3 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
LESS                             7            184            203            799
Javascript                      39            126             72            564
Python                          18            123             69            461
Markdown                         3             58             13            111
HTML                             3             15              0             79
YAML                             1              5              0             18
XML                              1              2              8              5
-------------------------------------------------------------------------------
SUM:                            72            513            365           2037
-------------------------------------------------------------------------------
```