### PR TITLE
Modified install docs to account for bundler

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -18,7 +18,7 @@ This will vary depending on your OS, but here's an example using Ubuntu:
 
 ```shell
 apt-get update
-apt-get install git gem python-pip
+apt-get install git python-pip
 gem install bundler
 pip install fabric
 ```
@@ -57,62 +57,4 @@ Now that the server is fully configured, we are ready to deploy our application.
 
 ```shell
 fab local_deploy
-```
-
-Setting up database (dev)
-===
-
-##Linux
-
-After running the `dev_setup_linux.bash` script, enter these into the terminal:
-
-```
-sudo -u postgres createuser --superuser sample_db_user
-sudo -u postgres psql -c "ALTER USER sample_db_user WITH PASSWORD 'sample_db_password';"
-sudo -u postgres createdb sample_db_name
-```
-
-Finally, export the required environment variables:
-
-```
-export DJANGO_SECRET_KEY='sample_secret_key'
-export DJANGO_DB_NAME='sample_db_name'
-export DJANGO_DB_USER='sample_db_user'
-export DJANGO_DB_PASSWORD='sample_db_password'
-```
-
-##OS X
-
-
-After running the `dev_setup_osx.bash` script, start the postgres server in a terminal by entering:
-
-```
-postgres -D /usr/local/var/postgres
-```
-Then enter these into a separate terminal:
-
-```
-sudo su _postgres
-createuser --superuser sample_db_user
-```
-
-Inside the Postgres terminal enter:
-
-```
-\password sample_db_password
-```
-
-Once prompted for the password enter `sample_db_password` again and then exit with `Ctrl+D`. Finally enter:
-
-```
-createdb sample_db_name
-```
-
-Finally, export the required environment variables:
-
-```
-export DJANGO_SECRET_KEY='sample_secret_key'
-export DJANGO_DB_NAME='sample_db_name'
-export DJANGO_DB_USER='sample_db_user'
-export DJANGO_DB_PASSWORD='sample_db_password'
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -9,7 +9,7 @@ We use Chef to configure our servers and automate our deployments.
 On your local machine, you will need the following packages to configure a server with Chef:
 
 - Git
-- Ruby
+- Ruby (>= 1.9.3)
 - Bundler
 - Python
 - Fabric
@@ -18,7 +18,8 @@ This will vary depending on your OS, but here's an example using Ubuntu:
 
 ```shell
 apt-get update
-apt-get install git bundler python-pip
+apt-get install git gem python-pip
+gem install bundler
 pip install fabric
 ```
 

--- a/docs/SETUP_DEVELOPMENT.md
+++ b/docs/SETUP_DEVELOPMENT.md
@@ -1,0 +1,57 @@
+Setting up database (dev)
+===
+
+##Linux
+
+After running the `dev_setup_linux.bash` script, enter these into the terminal:
+
+```
+sudo -u postgres createuser --superuser sample_db_user
+sudo -u postgres psql -c "ALTER USER sample_db_user WITH PASSWORD 'sample_db_password';"
+sudo -u postgres createdb sample_db_name
+```
+
+Finally, export the required environment variables:
+
+```
+export DJANGO_SECRET_KEY='sample_secret_key'
+export DJANGO_DB_NAME='sample_db_name'
+export DJANGO_DB_USER='sample_db_user'
+export DJANGO_DB_PASSWORD='sample_db_password'
+```
+
+##OS X
+
+
+After running the `dev_setup_osx.bash` script, start the postgres server in a terminal by entering:
+
+```
+postgres -D /usr/local/var/postgres
+```
+Then enter these into a separate terminal:
+
+```
+sudo su _postgres
+createuser --superuser sample_db_user
+```
+
+Inside the Postgres terminal enter:
+
+```
+\password sample_db_password
+```
+
+Once prompted for the password enter `sample_db_password` again and then exit with `Ctrl+D`. Finally enter:
+
+```
+createdb sample_db_name
+```
+
+Finally, export the required environment variables:
+
+```
+export DJANGO_SECRET_KEY='sample_secret_key'
+export DJANGO_DB_NAME='sample_db_name'
+export DJANGO_DB_USER='sample_db_user'
+export DJANGO_DB_PASSWORD='sample_db_password'
+```


### PR DESCRIPTION
Currently doing bundle install inside chef requires 1.9.3 Ruby.
Also, bundler is a gem, so we need to get gem and then do a `gem install bundler`