### PR TITLE
Clean up page indexing

### DIFF
--- a/src-frontend/app/controllers/edit-page-modal.js
+++ b/src-frontend/app/controllers/edit-page-modal.js
@@ -12,7 +12,7 @@ export default Ember.Controller.extend({
 
             var newElement = this.store.createRecord('element', {
                 page: page,
-                displayIndex: targetIndex
+                displayIndex: selectedIndex
             });
 
             newElement.save().then(function() {

--- a/src-frontend/app/controllers/edit-page-modal.js
+++ b/src-frontend/app/controllers/edit-page-modal.js
@@ -8,27 +8,23 @@ export default Ember.Controller.extend({
 
     actions: {
         addElement: function(selectedIndex) {
-            var targetIndex = selectedIndex + 1;
-            var elements = this.get('model.elements');
-            var elementsToBePushed = elements.filter(function(element) {
-                return element.get('displayIndex') >= targetIndex;
-            });
-
-            elementsToBePushed.forEach(function(element) {
-                element.incrementProperty('displayIndex');
-                // TODO: Find a way to batch these updates
-                element.save();
-            });
+            var page = this.get('model');
 
             var newElement = this.store.createRecord('element', {
-                page: this.get('model'),
+                page: page,
                 displayIndex: targetIndex
             });
+
+            newElement.save().then(function() {
+                page.reload();
+            });
         },
+
         deleteElement: function(element) {
             element.deleteRecord();
             element.save();
         },
+
         save: function() {
             this.get('model.elements').forEach(function(element) {
                 element.save();

--- a/src-frontend/app/controllers/procedure.js
+++ b/src-frontend/app/controllers/procedure.js
@@ -15,7 +15,7 @@ export default Ember.Controller.extend({
             });
 
             newPage.save().then(function() {
-                procedure.reload();
+                procedure.get('pages').reload();
             });
         },
 

--- a/src-frontend/app/controllers/procedure.js
+++ b/src-frontend/app/controllers/procedure.js
@@ -1,58 +1,33 @@
 import Ember from 'ember';
 
-export default Ember.ObjectController.extend({
+export default Ember.Controller.extend({
     pages: function() {
         return this.get('model.pages').sortBy('displayIndex');
     }.property('model.pages.@each.displayIndex'),
 
     actions: {
-        addElement: function(page, selectedIndex) {
-            var targetIndex = selectedIndex + 1;
-            var elements = page.get('elements');
-            var elementsToBePushed = elements.filter(function(element) {
-                return element.get('displayIndex') >= targetIndex;
-            });
-
-            elementsToBePushed.forEach(function(element) {
-                element.incrementProperty('displayIndex');
-                // TODO: Find a way to batch these updates
-                element.save();
-            });
-
-            var elementInfo = {
-                page: page,
-                displayIndex: targetIndex
-            };
-
-            this.send('showModal', 'add-element-modal', elementInfo);
-        },
         addPage: function(selectedIndex) {
-            var targetIndex = selectedIndex + 1;
-            var pages = this.get('model.pages');
-            var pagesToBePushed = pages.filter(function(page) {
-                return page.get('displayIndex') >= targetIndex;
-            });
-
-            pagesToBePushed.forEach(function(page) {
-                page.incrementProperty('displayIndex');
-                // TODO: Find a way to batch these updates
-                page.save();
-            });
+            var procedure = this.get('model');
 
             var newPage = this.store.createRecord('page', {
-                procedure: this.get('model'),
-                displayIndex: targetIndex
+                procedure: procedure,
+                displayIndex: selectedIndex
             });
 
-            newPage.save();
+            newPage.save().then(function() {
+                procedure.reload();
+            });
         },
+
         editPage: function(page) {
             this.send('showModal', 'edit-page-modal', page);
         },
+
         deletePage: function(page) {
             page.deleteRecord();
             page.save();
         },
+
         updateSortOrder: function(indices) {
             this.beginPropertyChanges();
 

--- a/src-frontend/app/helpers/plus-one.js
+++ b/src-frontend/app/helpers/plus-one.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function plusOne(params) {
+  return parseInt(params) + 1;
+}
+
+export default Ember.HTMLBars.makeBoundHelper(plusOne);

--- a/src-frontend/app/templates/components/page-list.hbs
+++ b/src-frontend/app/templates/components/page-list.hbs
@@ -8,7 +8,7 @@
                 <span class="add-condition mega-octicon octicon-diff-renamed"></span>
                 <span class="delete-page mega-octicon octicon-trashcan" {{action 'deletePage' page}}></span>
             </a>
-            <a class="add-page" {{action 'addPage' page.displayIndex}}>+</a>
+            <a class="add-page" {{action 'addPage' (plus-one page.displayIndex)}}>+</a>
         </li>
     {{/each}}
 </ul>

--- a/src-frontend/bower.json
+++ b/src-frontend/bower.json
@@ -4,7 +4,7 @@
     "ember": "1.13.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.17",
+    "ember-data": "~1.13.2",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/src-frontend/tests/unit/helpers/plus-one-test.js
+++ b/src-frontend/tests/unit/helpers/plus-one-test.js
@@ -1,0 +1,10 @@
+import { plusOne } from '../../../helpers/plus-one';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | plus one');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var result = plusOne(42);
+  assert.ok(result);
+});


### PR DESCRIPTION
Now that display indices are updated in the backend, we can get rid of the old client code.

Note: reordering is still broken. this is just for adding new pages