### PR TITLE
Fix JSHint errors

### DIFF
--- a/src-frontend/.jshintrc
+++ b/src-frontend/.jshintrc
@@ -28,5 +28,5 @@
   "white": false,
   "eqnull": true,
   "esnext": true,
-  "unused": true
+  "unused": "vars"
 }


### PR DESCRIPTION
Only check for unused variables; not unused function parameters