### PR TITLE
Fix staticfile errors

### DIFF
--- a/src-backend/sanaprotocolbuilder/settings.py
+++ b/src-backend/sanaprotocolbuilder/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',      # Dependency of django.contrib.auth
     'django.contrib.contenttypes',  # Track all of the models installed and provide object level permissions
     'django.contrib.auth',          # User auth system
+    'django.contrib.staticfiles',   # Serving static files on Django error pages
 
     # 3rd party apps
     'rest_framework',               # RESTful endpoint support
@@ -203,3 +204,13 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 # ------------------------------------------------------------------------------
 
 CORS_ORIGIN_ALLOW_ALL = True  # Temporary
+
+# ------------------------------------------------------------------------------
+# Static path
+# Since Django Rest Framework's error pages have the {% load staticfiles %} tag,
+# we need to include the staticfiles module and its configuration even if we
+# do not need static files
+# ------------------------------------------------------------------------------
+
+STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')


### PR DESCRIPTION
When the Rest framework tries to return an error page, it tries to load static files via the staticfiles module. Since we removed it back when we decoupled the frontend from the backend, the Rest framework can't properly serve up its error pages (e.g. 401 invalid token).

Fixes:
![screenshot from 2015-06-30 10 48 51](https://cloud.githubusercontent.com/assets/458691/8433731/9c66f4e2-1f15-11e5-82ce-7c463b42a6b2.png)
