### PR TITLE
Inject the owner automatically into created procedures

### DIFF
--- a/src-backend/api/serializer.py
+++ b/src-backend/api/serializer.py
@@ -80,6 +80,7 @@ class PageSerializer(serializers.ModelSerializer):
 
 
 class ProcedureSerializer(serializers.ModelSerializer):
+    owner = serializers.ReadOnlyField(source='owner.id')
 
     class Meta:
         model = models.Procedure

--- a/src-backend/api/tests/test_procedures.py
+++ b/src-backend/api/tests/test_procedures.py
@@ -1,0 +1,36 @@
+from django.test import TestCase, Client
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from nose.tools import assert_equals, assert_true
+from utils.decorators import initialize_permissions
+from utils.helpers import add_token_to_header
+from utils import factories
+import json
+
+
+class ProcedureTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.token = Token.objects.get(user=factories.UserFactory())
+        self.procedure_url = '/api/procedures/'
+        self.data = {
+            "title": "Example Title",
+            "author": "An Author"
+        }
+
+    @initialize_permissions
+    def test_created_procedure_has_correct_owner(self):
+        user = factories.UserFactory()
+
+        response = self.client.post(
+            path=self.procedure_url,
+            data=json.dumps(self.data),
+            content_type='application/json',
+            HTTP_AUTHORIZATION=add_token_to_header(user, self.token)
+        )
+
+        assert_equals(response.status_code, status.HTTP_200_OK)
+        body = json.loads(response.content)
+
+        assert_true('owner' in body)
+        assert_equals(body['owner'], user.id)

--- a/src-backend/api/views.py
+++ b/src-backend/api/views.py
@@ -13,10 +13,11 @@ class ProcedureViewSet(viewsets.ModelViewSet):
     model = models.Procedure
 
     def get_queryset(self):
-        self.resource_name = 'procedure'  # ensures that unless we override resource_name it will exist
-
         user = self.request.user
         return models.Procedure.objects.filter(owner=user)
+
+    def perform_create(self, serializer):
+        serializer.save(owner=self.request.user)
 
     @detail_route(methods=['get'])
     def generate(self, request, pk=None):

--- a/src-frontend/app/controllers/procedures/index.js
+++ b/src-frontend/app/controllers/procedures/index.js
@@ -7,8 +7,7 @@ export default Ember.Controller.extend({
             var procedureController = this;
             var procedure = this.store.createRecord('procedure', {
                 title: 'Surgery Follow-Up',
-                author: 'Partners for Care',
-                owner: 1
+                author: 'Partners for Care'
             });
 
             procedure.save().then(function() {


### PR DESCRIPTION
We no longer need to specify the owner when creating a procedure. It will be pulled out of the request and injected into the serializer.