### PR TITLE
Update and handle last_modified timestamps correctly.

### DIFF
--- a/src-backend/api/migrations/0006_auto_20150714_2302.py
+++ b/src-backend/api/migrations/0006_auto_20150714_2302.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0005_auto_20150703_2228'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='element',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='element',
+            name='last_modified',
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.AlterField(
+            model_name='page',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='page',
+            name='last_modified',
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.AlterField(
+            model_name='procedure',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='procedure',
+            name='last_modified',
+            field=models.DateTimeField(auto_now=True),
+        ),
+    ]

--- a/src-backend/api/models.py
+++ b/src-backend/api/models.py
@@ -8,8 +8,8 @@ class Procedure(models.Model):
     version = models.CharField(max_length=255, null=True)
     uuid = models.CharField(max_length=36, null=True)
     owner = models.ForeignKey(User)
-    last_modified = models.DateField(auto_now=True)
-    created = models.DateField(auto_now_add=True)
+    last_modified = models.DateTimeField(auto_now=True)
+    created = models.DateTimeField(auto_now_add=True)
 
     class Meta():
         app_label = 'api'
@@ -18,8 +18,14 @@ class Procedure(models.Model):
 class Page(models.Model):
     display_index = models.PositiveIntegerField()
     procedure = models.ForeignKey(Procedure, related_name='pages')
-    last_modified = models.DateField(auto_now=True)
-    created = models.DateField(auto_now_add=True)
+    last_modified = models.DateTimeField(auto_now=True)
+    created = models.DateTimeField(auto_now_add=True)
+
+    def save(self, **kwargs):
+        super(Page, self).save()
+
+        self.procedure.last_modified = self.last_modified
+        self.procedure.save()
 
     class Meta:
         app_label = 'api'
@@ -46,8 +52,14 @@ class Element(models.Model):
     question = models.TextField(null=True, blank=True)
     answer = models.TextField(null=True, blank=True)
     page = models.ForeignKey(Page, related_name='elements')
-    last_modified = models.DateField(auto_now=True)
-    created = models.DateField(auto_now_add=True)
+    last_modified = models.DateTimeField(auto_now=True)
+    created = models.DateTimeField(auto_now_add=True)
+
+    def save(self, **kwargs):
+        super(Element, self).save()
+
+        self.page.last_modified = self.last_modified
+        self.page.save()
 
     class Meta:
         app_label = 'api'

--- a/src-backend/api/tests/test_model_page.py
+++ b/src-backend/api/tests/test_model_page.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.db import IntegrityError
-from nose.tools import raises, assert_equals, assert_not_equals, nottest
+from nose.tools import raises, assert_equals, assert_not_equals, assert_true, nottest
 from api.models import Procedure, Page
 from utils import factories
 
@@ -74,4 +74,4 @@ class ProcedureTest(TestCase):
             page=page
         )
 
-        assert_not_equals(original_last_modified, page.last_modified)
+        assert_true(original_last_modified < page.last_modified)

--- a/src-backend/api/tests/test_model_page.py
+++ b/src-backend/api/tests/test_model_page.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError
 from nose.tools import raises, assert_equals, assert_not_equals, nottest
 from api.models import Procedure, Page
+from utils import factories
 
 
 class ProcedureTest(TestCase):
@@ -64,3 +65,13 @@ class ProcedureTest(TestCase):
             display_index=0,
             procedure=self.test_procedure1
         )
+
+    def test_updates_last_modified(self):
+        page = factories.PageFactory()
+        original_last_modified = page.last_modified
+
+        factories.ElementFactory(
+            page=page
+        )
+
+        assert_not_equals(original_last_modified, page.last_modified)

--- a/src-backend/api/tests/test_model_procedure.py
+++ b/src-backend/api/tests/test_model_procedure.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError
 from nose.tools import raises, assert_equals, assert_not_equals
 from api.models import Procedure
+from utils import factories
 import uuid
 
 
@@ -71,3 +72,13 @@ class ProcedureTest(TestCase):
             author='author',
             title=None
         )
+
+    def test_updates_last_modified(self):
+        procedure = factories.ProcedureFactory()
+        original_last_modified = procedure.last_modified
+
+        factories.PageFactory(
+            procedure=procedure
+        )
+
+        assert_not_equals(original_last_modified, procedure.last_modified)

--- a/src-backend/api/tests/test_model_procedure.py
+++ b/src-backend/api/tests/test_model_procedure.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.db import IntegrityError
-from nose.tools import raises, assert_equals, assert_not_equals
+from nose.tools import raises, assert_equals, assert_not_equals, assert_true
 from api.models import Procedure
 from utils import factories
 import uuid
@@ -73,7 +73,7 @@ class ProcedureTest(TestCase):
             title=None
         )
 
-    def test_updates_last_modified(self):
+    def test_page_update_updates_last_modified(self):
         procedure = factories.ProcedureFactory()
         original_last_modified = procedure.last_modified
 
@@ -81,4 +81,18 @@ class ProcedureTest(TestCase):
             procedure=procedure
         )
 
-        assert_not_equals(original_last_modified, procedure.last_modified)
+        assert_true(original_last_modified < procedure.last_modified)
+
+    def test_element_update_updates_last_modified(self):
+        procedure = factories.ProcedureFactory()
+        page = factories.PageFactory(
+            procedure=procedure
+        )
+
+        original_last_modified = procedure.last_modified
+
+        factories.ElementFactory(
+            page=page
+        )
+
+        assert_true(original_last_modified < procedure.last_modified)

--- a/src-frontend/app/controllers/procedures/index.js
+++ b/src-frontend/app/controllers/procedures/index.js
@@ -2,7 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
     procedures: function() {
-        return this.get('model').sortBy('lastModified').reverse();
+        return Ember.ArrayProxy.createWithMixins(Ember.SortableMixin, {
+            sortProperties: ['lastModified'],
+            sortAscending: false,
+            content: this.get('model')
+        });
     }.property('model.@each.lastModified'),
 
     actions: {

--- a/src-frontend/app/controllers/procedures/index.js
+++ b/src-frontend/app/controllers/procedures/index.js
@@ -1,6 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+    procedures: function() {
+        return this.get('model').sortBy('lastModified').reverse();
+    }.property('model.@each.lastModified'),
+
     actions: {
         createProcedure: function() {
             // TODO: Deal with owner ID and user-inputted information

--- a/src-frontend/app/helpers/date-string.js
+++ b/src-frontend/app/helpers/date-string.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function dateString(params) {
+    return params[0].toDateString();
+}
+
+export default Ember.HTMLBars.makeBoundHelper(dateString);

--- a/src-frontend/app/models/procedure.js
+++ b/src-frontend/app/models/procedure.js
@@ -6,5 +6,7 @@ export default DS.Model.extend({
     version: DS.attr('string'),
     uuid: DS.attr('string'),
     owner: DS.attr('number'),
+    lastModified: DS.attr('date'),
+    created: DS.attr('date'),
     pages: DS.hasMany('page', { async: true })
 });

--- a/src-frontend/app/templates/components/procedure-card.hbs
+++ b/src-frontend/app/templates/components/procedure-card.hbs
@@ -1,6 +1,6 @@
 {{#link-to 'procedure' procedure}}{{procedure.title}}{{/link-to}}
 
 <div class="card-footer">
-    <span>June 05, 2015</span>
+    <span>{{date-string procedure.lastModified}}</span>
     <span class="octicon octicon-x delete-procedure" {{action 'deleteProcedure' procedure}}/>
 </div>

--- a/src-frontend/app/templates/procedures/index.hbs
+++ b/src-frontend/app/templates/procedures/index.hbs
@@ -3,7 +3,7 @@
 <div class="procedure-list">
     <a {{action "createProcedure"}} class="create-procedure btn btn-primary">Create Procedure</a>
     <ul class="procedures">
-        {{#each procedure in model}}
+        {{#each procedure in procedures}}
             {{procedure-card procedure=procedure}}
         {{/each}}
     </ul>


### PR DESCRIPTION
Depends on #187 because of UI.

Does two things.

1. Fixes updating last_modified timestamps for models on the server so that child elements (pages, elements) cascade their updates to their parents.
2. Makes it so that procedures use their actual last_modified timestamp and are sorted in the correct order.

