### PR TITLE
Added in flash messages

### DIFF
--- a/src-frontend/app/controllers/signup.js
+++ b/src-frontend/app/controllers/signup.js
@@ -11,6 +11,7 @@ export default Ember.Controller.extend({
     actions: {
         signup: function() {
             var controller = this;
+            var flashMessages = Ember.get(this, 'flashMessages');
             Ember.$.post(ENV.APP.API_HOST + '/auth/signup', {
                 email: this.get('email'),
                 username: this.get('username'),
@@ -19,11 +20,10 @@ export default Ember.Controller.extend({
                 accept_tos: this.get('accept_tos')
             }, function(response) {
                 if (response.success === true && response.token) {
+                    flashMessages.success('Account was created successfully!');
                     controller.transitionToRoute('login');
                 } else {
-                    // TODO: Issue #123
-                    // Add flash messages to show form errors
-                    alert('An error occurred during registration');
+                    flashMessages.danger('An error occurred during registration!');
                 }
             });
         }

--- a/src-frontend/app/styles/base.less
+++ b/src-frontend/app/styles/base.less
@@ -303,6 +303,14 @@ ul.element{
     }
 }
 
+div.alert {
+    width: 60%;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 10px;
+    margin-bottom: -20px;
+}
+
 ul.choices-list{
     @input-size:    30px;
     @input-padding: 5px;

--- a/src-frontend/app/templates/application.hbs
+++ b/src-frontend/app/templates/application.hbs
@@ -1,2 +1,5 @@
+{{#each flashMessages.queue as |flash|}}
+    {{flash-message flash=flash}}
+{{/each}}
 {{outlet}}
 {{outlet 'modal'}}

--- a/src-frontend/package.json
+++ b/src-frontend/package.json
@@ -25,6 +25,7 @@
         "ember-cli-babel": "^5.0.0",
         "ember-cli-content-security-policy": "0.4.0",
         "ember-cli-dependency-checker": "^1.0.0",
+        "ember-cli-flash": "1.3.3",
         "ember-cli-htmlbars": "0.7.6",
         "ember-cli-ic-ajax": "0.1.1",
         "ember-cli-inject-live-reload": "^1.3.0",

--- a/src-frontend/tests/helpers/flash-message.js
+++ b/src-frontend/tests/helpers/flash-message.js
@@ -1,0 +1,3 @@
+import FlashObject from 'ember-cli-flash/flash/object';
+
+FlashObject.reopen({ _setInitialState: null });

--- a/src-frontend/tests/test-helper.js
+++ b/src-frontend/tests/test-helper.js
@@ -1,4 +1,6 @@
 import resolver from './helpers/resolver';
+import flashMessageHelper from './helpers/flash-message';
+
 import {
     setResolver
 } from 'ember-qunit';


### PR DESCRIPTION
I've used https://github.com/poteto/ember-cli-flash to implement the flash messages. So far we only have it in the sign up page, but @ConnorCimowsky can add them into the login flow (I'm not 100% sure how to work the auth flow so I'll leave that to Connor).

The CSS changes are because by default the flash message takes up pretty much 100% of the screen, which doesn't look very good.

Resolves #123 

Screenshot: 

<img width="803" alt="screen shot 2015-07-17 at 4 04 53 pm" src="https://cloud.githubusercontent.com/assets/978947/8756107/b231e706-2c9d-11e5-934b-86a6c19fff14.png">


TODO: Add form validations and add the errors into the flash messages (i.e. missing fields). Will do in another ticket