### PR TITLE
Add element unit tests and refactor page and procedure unit tests

### DIFF
--- a/src-backend/api/models.py
+++ b/src-backend/api/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 
 
 class Procedure(models.Model):
@@ -56,6 +57,9 @@ class Element(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
     def save(self, **kwargs):
+        if self.element_type and (self.element_type, self.element_type) not in self.TYPES:
+            raise IntegrityError('Invalid element type')
+
         super(Element, self).save()
 
         self.page.last_modified = self.last_modified

--- a/src-backend/api/tests/test_model_element.py
+++ b/src-backend/api/tests/test_model_element.py
@@ -1,0 +1,90 @@
+from django.test import TestCase
+from django.db import IntegrityError
+from nose.tools import raises, assert_equals, assert_not_equals
+from api.models import Element
+from utils import factories
+
+
+class ElementTest(TestCase):
+    def test_elements_required(self):
+        page = factories.PageFactory()
+        element = Element.objects.create(
+            display_index=0,
+            page=page
+        )
+
+        assert_equals(element.display_index, 0)
+        assert_equals(element.page, page)
+
+    def test_elements_all_properties(self):
+        page = factories.PageFactory()
+        Element.objects.create(
+            display_index=0,
+            eid='eid',
+            element_type='SELECT',
+            choices='[one]',
+            numeric='DIALPAD',
+            concept='TEST',
+            question='test question',
+            answer='',
+            page=page
+        )
+
+        element = Element.objects.get(concept='TEST')
+
+        assert_equals(element.display_index, 0)
+        assert_equals(element.eid, 'eid')
+        assert_equals(element.element_type, 'SELECT')
+        assert_equals(element.choices, '[one]')
+        assert_equals(element.numeric, 'DIALPAD')
+        assert_equals(element.concept, 'TEST')
+        assert_equals(element.question, 'test question')
+        assert_equals(element.answer, '')
+        assert_equals(element.page, page)
+        assert_not_equals(element.last_modified, None)
+        assert_not_equals(element.created, None)
+
+        @raises(IntegrityError)
+        def test_display_index_negative(self):
+            Element.objects.create(
+                display_index=-1,
+                page=factories.PageFactory()
+            )
+
+        @raises(IntegrityError)
+        def test_element_type_invalid(self):
+            Element.objects.create(
+                display_index=0,
+                page=factories.PageFactory(),
+                element_type='BAD'
+            )
+
+        def test_element_type_select(self):
+            assert_element_type_valid('SELECT')
+
+        def test_element_type_multi_select(self):
+            assert_element_type_valid('MULTI_SELECT')
+
+        def test_element_type_radio(self):
+            assert_element_type_valid('RADIO')
+
+        def test_element_type_gps(self):
+            assert_element_type_valid('SOUND')
+
+        def test_element_type_sound(self):
+            assert_element_type_valid('SOUND')
+
+        def test_element_type_picture(self):
+            assert_element_type_valid('PICTURE')
+
+        def test_element_type_entry(self):
+            assert_element_type_valid('ENTRY')
+
+# HELPERS
+
+        def assert_element_type_valid(self, element_type):
+            element = factories.ElementFactory(
+                element_type=element_type
+            )
+
+            assert_not_equals(element, None)

--- a/src-backend/api/tests/test_model_element.py
+++ b/src-backend/api/tests/test_model_element.py
@@ -24,67 +24,86 @@ class ElementTest(TestCase):
             element_type='SELECT',
             choices='[one]',
             numeric='DIALPAD',
-            concept='TEST',
+            concept='TESTCONCEPT',
             question='test question',
             answer='',
             page=page
         )
 
-        element = Element.objects.get(concept='TEST')
+        element = Element.objects.get(concept='TESTCONCEPT')
 
         assert_equals(element.display_index, 0)
         assert_equals(element.eid, 'eid')
         assert_equals(element.element_type, 'SELECT')
         assert_equals(element.choices, '[one]')
         assert_equals(element.numeric, 'DIALPAD')
-        assert_equals(element.concept, 'TEST')
+        assert_equals(element.concept, 'TESTCONCEPT')
         assert_equals(element.question, 'test question')
         assert_equals(element.answer, '')
         assert_equals(element.page, page)
         assert_not_equals(element.last_modified, None)
         assert_not_equals(element.created, None)
 
-        @raises(IntegrityError)
-        def test_display_index_negative(self):
-            Element.objects.create(
-                display_index=-1,
-                page=factories.PageFactory()
-            )
+    @raises(IntegrityError)
+    def test_display_index_negative(self):
+        Element.objects.create(
+            display_index=-1,
+            page=factories.PageFactory()
+        )
 
-        @raises(IntegrityError)
-        def test_element_type_invalid(self):
-            Element.objects.create(
-                display_index=0,
-                page=factories.PageFactory(),
-                element_type='BAD'
-            )
+    @raises(IntegrityError)
+    def test_element_type_invalid(self):
+        Element.objects.create(
+            display_index=0,
+            page=factories.PageFactory(),
+            element_type='BAD'
+        )
 
-        def test_element_type_select(self):
-            assert_element_type_valid('SELECT')
+    def test_element_type_select(self):
+        self.assert_element_type_valid('SELECT')
 
-        def test_element_type_multi_select(self):
-            assert_element_type_valid('MULTI_SELECT')
+    def test_element_type_multi_select(self):
+        self.assert_element_type_valid('MULTI_SELECT')
 
-        def test_element_type_radio(self):
-            assert_element_type_valid('RADIO')
+    def test_element_type_radio(self):
+        self.assert_element_type_valid('RADIO')
 
-        def test_element_type_gps(self):
-            assert_element_type_valid('SOUND')
+    def test_element_type_gps(self):
+        self.assert_element_type_valid('SOUND')
 
-        def test_element_type_sound(self):
-            assert_element_type_valid('SOUND')
+    def test_element_type_sound(self):
+        self.assert_element_type_valid('SOUND')
 
-        def test_element_type_picture(self):
-            assert_element_type_valid('PICTURE')
+    def test_element_type_picture(self):
+        self.assert_element_type_valid('PICTURE')
 
-        def test_element_type_entry(self):
-            assert_element_type_valid('ENTRY')
+    def test_element_type_entry(self):
+        self.assert_element_type_valid('ENTRY')
+
+    def test_orders_properly(self):
+        page = factories.PageFactory()
+
+        element1 = factories.ElementFactory(
+            display_index=1,
+            page=page
+        )
+
+        element2 = factories.ElementFactory(
+            display_index=0,
+            page=page
+        )
+
+        elements = Element.objects.all()
+
+        assert_equals(len(elements), 2)
+        assert_equals(elements[0], element2)
+        assert_equals(elements[1], element1)
 
 # HELPERS
 
-        def assert_element_type_valid(self, element_type):
-            element = factories.ElementFactory(
-                element_type=element_type
-            )
+    def assert_element_type_valid(self, element_type):
+        element = factories.ElementFactory(
+            element_type=element_type
+        )
 
-            assert_not_equals(element, None)
+        assert_not_equals(element, None)


### PR DESCRIPTION
Gives some validation for the element models and cleans up the page/procedure model tests a lot.
Additionally, covers some missing cases from procedures and pages as well.

Also fixes a bug that was found in creating the element tests. The server was not validating the type of the element properly and that is now fixed.

Closes #101 