### PR TITLE
Don't use sudo for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - '2.7'


### PR DESCRIPTION
This allows Travis to use the new container-based infrastructure:

http://docs.travis-ci.com/user/migrating-from-legacy/