### PR TITLE
Clean up some of the create page UX

### DIFF
--- a/src-frontend/app/controllers/procedure.js
+++ b/src-frontend/app/controllers/procedure.js
@@ -45,20 +45,26 @@ export default Ember.Controller.extend({
             newPage.save().then(function() {
                 procedure.get('pages').reload();
             }).then(function() {
-                var newElement = procedureController.store.createRecord('element', {
-                    page: newPage,
-                    displayIndex: 0,
-                    eid: newPage.get('id')
-                });
-
-                newElement.save().then(function() {
-                    procedureController.send('editPage', newPage);
-                });
+                procedureController.send('editPage', newPage);
             });
         },
 
         editPage: function(page) {
-            this.send('showModal', 'edit-page-modal', page);
+            var procedureController = this;
+
+            if (page.get('elements').length === 0) {
+                var newElement = this.store.createRecord('element', {
+                    page: page,
+                    displayIndex: 0,
+                    eid: page.get('id')
+                });
+
+                newElement.save().then(function() {
+                    procedureController.send('showModal', 'edit-page-modal', page);
+                });
+            } else {
+                this.send('showModal', 'edit-page-modal', page);
+            }
         },
 
         deletePage: function(page) {

--- a/src-frontend/app/templates/components/modal-dialog.hbs
+++ b/src-frontend/app/templates/components/modal-dialog.hbs
@@ -9,7 +9,7 @@
                 {{yield}}
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 <button type="button" class="btn btn-primary" {{action 'save'}}>Save</button>
             </div>
         </div>


### PR DESCRIPTION
This change moves the logic for adding an element to a page automatically to the edit functionality of the page creation versus on creation. It also changes "cancel" to "close" to make it more explicit what it is doing.

Sorta resolves #178 in a different way.