### PR TITLE
Logger use native console when message is an object

### DIFF
--- a/src-backbone/app/js/utils/logger.js
+++ b/src-backbone/app/js/utils/logger.js
@@ -4,28 +4,63 @@ var colors = require('colors');
 module.exports = function(is_debug) {
     return {
         error: function(message) {
-            if (!is_debug) return;
-            console.error('%c' + colors.red(message), 'color:Red');
+            if (!is_debug) {
+                return;
+            }
+
+            if (_.isString(message)) {
+                console.error('%c' + colors.red(message), 'color:Red');
+            } else {
+                console.error(message);
+            }
         },
 
         warn: function(message) {
-            if (!is_debug) return;
-            console.warn('%c' + colors.yellow(message), 'color:OrangeRed');
+            if (!is_debug) {
+                return;
+            }
+
+            if (_.isString(message)) {
+                console.warn('%c' + colors.yellow(message), 'color:OrangeRed');
+            } else {
+                console.warn(message);
+            }
         },
 
         info: function (message) {
-            if (!is_debug) return;
-            console.info('%c' + colors.green(message), 'color:Green');
+            if (!is_debug) {
+                return;
+            }
+
+            if (_.isString(message)) {
+                console.info('%c' + colors.green(message), 'color:Green');
+            } else {
+                console.info(message);
+            }
         },
 
         log: function (message) {
-            if (!is_debug) return;
-            console.log('%c' + colors.blue(message), 'color:Blue');
+            if (!is_debug) {
+                return;
+            }
+
+            if (_.isString(message)) {
+                console.log('%c' + colors.blue(message), 'color:Blue');
+            } else {
+                console.log(message);
+            }
         },
 
         debug: function (message) {
-            if (!is_debug) return;
-            console.debug('%c' + colors.grey(message), 'color:#999');
+            if (!is_debug) {
+                return;
+            }
+
+            if (_.isString(message)) {
+                console.debug('%c' + colors.grey(message), 'color:#999');
+            } else {
+                console.debug(message);
+            }
         },
     };
 };


### PR DESCRIPTION
Use native console when trying to print non-strings.