### PR TITLE
Updated procedure API to include only_return_id

### DIFF
--- a/src-django/api/serializer.py
+++ b/src-django/api/serializer.py
@@ -95,3 +95,12 @@ class ProcedureSerializer(serializers.ModelSerializer):
             'last_modified',
             'created'
         )
+
+
+class ProcedureDetailSerializer(ProcedureSerializer):
+    owner = serializers.ReadOnlyField(source='owner.id')
+
+    class Meta(ProcedureSerializer.Meta):
+        model = models.Procedure
+        depth = 1
+        fields = ProcedureSerializer.Meta.fields

--- a/src-django/api/tests/test_procedures.py
+++ b/src-django/api/tests/test_procedures.py
@@ -9,28 +9,48 @@ import json
 
 
 class ProcedureTest(TestCase):
+
     def setUp(self):
         self.client = Client()
         self.token = Token.objects.get(user=factories.UserFactory())
-        self.procedure_url = '/api/procedures/'
+        self.procedure_url = '/api/procedures'
         self.data = {
-            "title": "Example Title",
-            "author": "An Author"
+            'title': 'Example Title',
+            'author': 'An Author'
         }
+        self.user = factories.UserFactory()
+        initialize_permissions
 
-    @initialize_permissions
     def test_created_procedure_has_correct_owner(self):
-        user = factories.UserFactory()
-
         response = self.client.post(
             path=self.procedure_url,
             data=json.dumps(self.data),
             content_type='application/json',
-            HTTP_AUTHORIZATION=add_token_to_header(user, self.token)
+            HTTP_AUTHORIZATION=add_token_to_header(self.user, self.token)
+        )
+
+        assert_equals(response.status_code, status.HTTP_201_CREATED)
+        body = json.loads(response.content)
+
+        assert_true('owner' in body)
+        assert_equals(body['owner'], self.user.id)
+
+    def test_procedure_comes_with_pages(self):
+        procedure = factories.ProcedureFactory(owner=self.user)
+        factories.PageFactory(procedure=procedure)
+        flags = {
+            'only_return_id': 'false'
+        }
+
+        response = self.client.get(
+            path=self.procedure_url,
+            data=flags,
+            content_type='application/json',
+            HTTP_AUTHORIZATION=add_token_to_header(self.user, self.token)
         )
 
         assert_equals(response.status_code, status.HTTP_200_OK)
         body = json.loads(response.content)
-
-        assert_true('owner' in body)
-        assert_equals(body['owner'], user.id)
+        pages = body[0]['pages']
+        assert_equals(len(pages), 1)
+        assert_true('display_index' in pages[0])

--- a/src-django/api/tests/utils/helpers.py
+++ b/src-django/api/tests/utils/helpers.py
@@ -1,6 +1,6 @@
 from rest_framework.authtoken.models import Token
 
 
-def add_token_to_header(self, user, token):
+def add_token_to_header(user, token):
     key = Token.objects.get(user=user).key
     return "Token {0}".format(key)

--- a/src-django/api/views.py
+++ b/src-django/api/views.py
@@ -9,12 +9,17 @@ import serializer
 
 
 class ProcedureViewSet(viewsets.ModelViewSet):
-    serializer_class = serializer.ProcedureSerializer
     model = models.Procedure
 
     def get_queryset(self):
         user = self.request.user
         return models.Procedure.objects.filter(owner=user)
+
+    def get_serializer_class(self):
+        request_flag = 'only_return_id'
+        if self.request.GET.get(request_flag) == 'true':
+            return serializer.ProcedureSerializer
+        return serializer.ProcedureDetailSerializer
 
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)


### PR DESCRIPTION
only_return_id flag for procedures, when set true, will result in a
response with only page ids for each procedure. If however it is set
to false, then instead of page ids, the full page object will be returned.

Resolves #256