### PR TITLE
Implement condition logic serialization

### DIFF
--- a/src-django/api/migrations/0009_auto_20160211_2019.py
+++ b/src-django/api/migrations/0009_auto_20160211_2019.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0008_conditionnode_showif'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='showif',
+            name='condition',
+        ),
+        migrations.AddField(
+            model_name='conditionnode',
+            name='show_if',
+            field=models.ForeignKey(related_name='conditions', blank=True, to='api.ShowIf', null=True),
+        ),
+        migrations.AlterField(
+            model_name='showif',
+            name='page',
+            field=models.ForeignKey(related_name='show_if', to='api.Page'),
+        ),
+    ]

--- a/src-django/api/startup.py
+++ b/src-django/api/startup.py
@@ -1,13 +1,13 @@
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
-from models import Procedure, Page, Element, Concept
+from models import Procedure, Page, Element, Concept, ShowIf, ConditionNode
 
 
 def grant_permissions():
     # Grant model permissions to the appropriate user groups
     normal_users_group, created = Group.objects.get_or_create(name=settings.NORMAL_USER_GROUP)
-    models = [Procedure, Page, Element, Concept]
+    models = [Procedure, Page, Element, Concept, ShowIf, ConditionNode]
 
     for m in models:
         content_type = ContentType.objects.get_for_model(m)

--- a/src-django/api/tests/test_conditionals.py
+++ b/src-django/api/tests/test_conditionals.py
@@ -1,0 +1,71 @@
+from django.test import TestCase, Client
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from nose.tools import assert_equals
+from api.startup import grant_permissions
+from utils.helpers import add_token_to_header
+from utils import factories
+import json
+
+
+class ConditionalTest(TestCase):
+    def setUp(self):
+        self.client = Client(enforce_csrf_checks=False)
+        self.user = factories.UserFactory()
+        self.element = factories.ElementFactory()
+        self.token = Token.objects.get(user=self.user)
+        self.conditional_url = '/api/conditionals'
+        self.data = {
+            "page": self.element.page.pk,
+            "conditions": [
+                {
+                    "node_type": "NOT",
+                    "children": [
+                        {
+                            "node_type": "AND",
+                            "children": [
+                                {
+                                    "criteria_element": self.element.pk,
+                                    "node_type": "CRITERIA",
+                                    "criteria_type": "EQUALS",
+                                    "value": "foo"
+                                },
+                                {
+                                    "criteria_element": self.element.pk,
+                                    "node_type": "CRITERIA",
+                                    "criteria_type": "EQUALS",
+                                    "value": "bar"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        grant_permissions()
+
+    def test_conditional_works(self):
+        response = self.client.post(
+            path=self.conditional_url,
+            data=json.dumps(self.data),
+            content_type='application/json',
+            HTTP_AUTHORIZATION=add_token_to_header(self.user, self.token)
+        )
+
+        assert_equals(response.status_code, status.HTTP_201_CREATED)
+        body = json.loads(response.content)
+        assert_equals(body['page'], self.data['page'])
+        assert_equals(len(body['conditions']), len(self.data['conditions']))
+
+        for body_cond, data_cond in zip(body['conditions'], self.data['conditions']):
+            assert_equals(body_cond['node_type'], data_cond['node_type'])
+
+            for body_cond_2, data_cond_2 in zip(body_cond['children'], data_cond['children']):
+                assert_equals(body_cond_2['node_type'], data_cond_2['node_type'])
+
+                for body_cond_3, data_cond_3 in zip(body_cond_2['children'], data_cond_2['children']):
+                    assert_equals(body_cond_3['node_type'], data_cond_3['node_type'])
+                    assert_equals(body_cond_3['criteria_type'], data_cond_3['criteria_type'])
+                    assert_equals(body_cond_3['criteria_element'], data_cond_3['criteria_element'])
+                    assert_equals(body_cond_3['value'], data_cond_3['value'])

--- a/src-django/api/tests/test_model_condition_node.py
+++ b/src-django/api/tests/test_model_condition_node.py
@@ -8,14 +8,32 @@ from utils import factories
 class ConditionTest(TestCase):
     @raises(IntegrityError)
     def test_invalid_node_type(self):
-        ConditionNode.objects.create(node_type='foo')
+        ConditionNode.objects.create(
+            node_type='foo',
+            parent=factories.NotConditionFactory()
+        )
+
+    @raises(IntegrityError)
+    def test_no_parent_or_show_if(self):
+        ConditionNode.objects.create(
+            node_type='NOT'
+        )
+
+    @raises(IntegrityError)
+    def test_both_show_if_and_parent(self):
+        ConditionNode.objects.create(
+            node_type='NOT',
+            parent=factories.NotConditionFactory(),
+            show_if=factories.ShowIfFactory()
+        )
 
     @raises(IntegrityError)
     def test_no_criteria_type(self):
         ConditionNode.objects.create(
             node_type='CRITERIA',
             criteria_type=None,
-            criteria_element=factories.ElementFactory()
+            criteria_element=factories.ElementFactory(),
+            parent=factories.NotConditionFactory()
         )
 
     @raises(IntegrityError)
@@ -23,7 +41,8 @@ class ConditionTest(TestCase):
         ConditionNode.objects.create(
             node_type='CRITERIA',
             criteria_type='foo',
-            criteria_element=factories.ElementFactory()
+            criteria_element=factories.ElementFactory(),
+            parent=factories.NotConditionFactory()
         )
 
     @raises(IntegrityError)
@@ -31,39 +50,49 @@ class ConditionTest(TestCase):
         ConditionNode.objects.create(
             node_type='CRITERIA',
             criteria_type='EQUALS',
-            criteria_element=None
+            criteria_element=None,
+            parent=factories.NotConditionFactory()
         )
 
     def test_creates_and_condition(self):
+        show_if = factories.ShowIfFactory()
         ConditionNode.objects.create(
-            node_type='AND'
+            node_type='AND',
+            show_if=show_if
         )
 
         condition = ConditionNode.objects.get(node_type='AND')
 
         assert_equals(condition.node_type, 'AND')
+        assert_equals(condition.show_if, show_if)
         assert_is_not_none(condition.last_modified)
         assert_is_not_none(condition.created)
 
     def test_creates_or_condition(self):
+        show_if = factories.ShowIfFactory()
         ConditionNode.objects.create(
-            node_type='OR'
+            node_type='OR',
+            show_if=show_if
         )
 
         condition = ConditionNode.objects.get(node_type='OR')
 
         assert_equals(condition.node_type, 'OR')
+        assert_equals(condition.show_if, show_if)
         assert_is_not_none(condition.last_modified)
         assert_is_not_none(condition.created)
 
     def test_creates_not_condition(self):
+        show_if = factories.ShowIfFactory()
         ConditionNode.objects.create(
-            node_type='NOT'
+            node_type='NOT',
+            show_if=show_if
         )
 
         condition = ConditionNode.objects.get(node_type='NOT')
 
         assert_equals(condition.node_type, 'NOT')
+        assert_equals(condition.show_if, show_if)
         assert_is_not_none(condition.last_modified)
         assert_is_not_none(condition.created)
 
@@ -77,7 +106,9 @@ class ConditionTest(TestCase):
         self.assert_creates_criteria('LESSER')
 
     def test_creates_simple_and(self):
-        root = factories.AndConditionFactory()
+        root = factories.AndConditionFactory(
+            show_if=factories.ShowIfFactory()
+        )
         factories.CriteriaConditionFactory(
             parent=root
         )
@@ -90,7 +121,9 @@ class ConditionTest(TestCase):
         assert_equals(condition.children.count(), 2)
 
     def test_creates_simple_or(self):
-        root = factories.OrConditionFactory()
+        root = factories.OrConditionFactory(
+            show_if=factories.ShowIfFactory()
+        )
         factories.CriteriaConditionFactory(
             parent=root
         )
@@ -103,7 +136,9 @@ class ConditionTest(TestCase):
         assert_equals(condition.children.count(), 2)
 
     def test_creates_simple_not(self):
-        root = factories.NotConditionFactory()
+        root = factories.NotConditionFactory(
+            show_if=factories.ShowIfFactory()
+        )
         factories.CriteriaConditionFactory(
             parent=root
         )
@@ -113,7 +148,9 @@ class ConditionTest(TestCase):
         assert_equals(condition.children.count(), 1)
 
     def test_creates_complex_structure(self):
-        root = factories.OrConditionFactory()
+        root = factories.OrConditionFactory(
+            show_if=factories.ShowIfFactory()
+        )
         lnode = factories.AndConditionFactory(
             parent=root
         )
@@ -152,11 +189,13 @@ class ConditionTest(TestCase):
 
     def assert_creates_criteria(self, criteria_type):
         element = factories.ElementFactory()
+        show_if = factories.ShowIfFactory()
         ConditionNode.objects.create(
             node_type='CRITERIA',
             criteria_element=element,
             criteria_type=criteria_type,
-            value='value'
+            value='value',
+            show_if=show_if
         )
 
         condition = ConditionNode.objects.get(value='value')
@@ -165,5 +204,6 @@ class ConditionTest(TestCase):
         assert_equals(condition.criteria_element, element)
         assert_equals(condition.criteria_type, criteria_type)
         assert_equals(condition.value, 'value')
+        assert_equals(condition.show_if, show_if)
         assert_is_not_none(condition.last_modified)
         assert_is_not_none(condition.created)

--- a/src-django/api/tests/test_model_show_if.py
+++ b/src-django/api/tests/test_model_show_if.py
@@ -6,26 +6,30 @@ from utils import factories
 
 class ShowIfTest(TestCase):
     def test_create_showif(self):
-        condition = factories.CriteriaConditionFactory()
         page = factories.PageFactory()
 
-        ShowIf.objects.create(
-            page=page,
-            condition=condition
+        show_if = ShowIf.objects.create(
+            page=page
         )
 
-        showif = ShowIf.objects.get(page=page)
+        condition = factories.CriteriaConditionFactory(
+            show_if=show_if
+        )
 
-        assert_equals(showif.page, page)
-        assert_equals(showif.condition, condition)
-        assert_not_equals(showif.last_modified, None)
-        assert_not_equals(showif.created, None)
+        show_if = ShowIf.objects.get(page=page)
+
+        assert_equals(show_if.page, page)
+        assert_equals(show_if.conditions.count(), 1)
+        assert_equals(show_if.conditions.all()[0], condition)
+        assert_not_equals(show_if.last_modified, None)
+        assert_not_equals(show_if.created, None)
 
     def test_creates_complex_structure(self):
-        root = factories.OrConditionFactory()
-        showif = factories.ShowIfFactory(
-            condition=root
+        show_if = factories.ShowIfFactory()
+        root = factories.OrConditionFactory(
+            show_if=show_if
         )
+
         lnode = factories.AndConditionFactory(
             parent=root
         )
@@ -48,8 +52,8 @@ class ShowIfTest(TestCase):
             parent=rnode
         )
 
-        showif_db = ShowIf.objects.get(pk=showif.id)
-        condition = showif_db.condition
+        showif_db = ShowIf.objects.get(pk=show_if.id)
+        condition = showif_db.conditions.all()[0]
         assert_equals(condition, root)
         assert_equals(condition.children.count(), 2)
 

--- a/src-django/api/tests/utils/factories.py
+++ b/src-django/api/tests/utils/factories.py
@@ -55,6 +55,13 @@ class ConceptFactory(factory.django.DjangoModelFactory):
     constraint = 'yes;no'
 
 
+class ShowIfFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.ShowIf
+
+    page = factory.SubFactory(PageFactory)
+
+
 class CriteriaConditionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.ConditionNode
@@ -88,11 +95,3 @@ class NotConditionFactory(factory.django.DjangoModelFactory):
 
     parent = None
     node_type = 'NOT'
-
-
-class ShowIfFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = models.ShowIf
-
-    page = factory.SubFactory(PageFactory)
-    condition = factory.SubFactory(CriteriaConditionFactory)

--- a/src-django/api/urls.py
+++ b/src-django/api/urls.py
@@ -1,14 +1,14 @@
 from django.conf.urls import url, include
 from rest_framework import routers
-from views import ProcedureViewSet, PageViewSet, ElementViewSet, ConceptViewSet
 from startup import run_once
-
+import views
 
 router = routers.SimpleRouter(trailing_slash=False)
-router.register(r'procedures', ProcedureViewSet, base_name='procedure')
-router.register(r'pages', PageViewSet, base_name='page')
-router.register(r'elements', ElementViewSet, base_name='element')
-router.register(r'concepts', ConceptViewSet, base_name='concept')
+router.register(r'procedures', views.ProcedureViewSet, base_name='procedure')
+router.register(r'pages', views.PageViewSet, base_name='page')
+router.register(r'elements', views.ElementViewSet, base_name='element')
+router.register(r'concepts', views.ConceptViewSet, base_name='concept')
+router.register(r'conditionals', views.ShowIfViewSet, base_name='conditional')
 
 urlpatterns = [
     url(r'^', include(router.urls))

--- a/src-django/api/views.py
+++ b/src-django/api/views.py
@@ -80,3 +80,12 @@ class ConceptViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return models.Concept.objects
+
+
+class ShowIfViewSet(viewsets.ModelViewSet):
+    model = models.ShowIf
+    serializer_class = serializer.ShowIfSerializer
+
+    def get_queryset(self):
+        user = self.request.user
+        return models.ShowIf.objects.filter(page__procedure__owner_id__exact=user.id)

--- a/src-django/requirements.txt
+++ b/src-django/requirements.txt
@@ -7,6 +7,7 @@ django-cors-headers==1.1.0
 django-filter==0.12.0
 django-nose==1.4.3
 djangorestframework==3.3.2
+djangorestframework-recursive==0.1.1
 django-extensions==1.6.1
 factory-boy==2.6.0
 flake8==2.5.1


### PR DESCRIPTION
Still missing a lot of tests, but this should be the serialization and api for condition logic.

Example POST:

```
{
    "page":1,
    "conditions": [
        {
            "node_type": "NOT",
            "children": [
                {
                    "node_type": "AND",
                    "children": [
                        {
                            "criteria_element": 3,
                            "node_type": "CRITERIA",
                            "criteria_type": "EQUALS",
                            "value": "foo"
                        },
                        {
                            "criteria_element": 3,
                            "node_type": "CRITERIA",
                            "criteria_type": "EQUALS",
                            "value": "bar"
                        }
                    ]
                }
            ]
        }
    ]
}
```