### PR TITLE
Added a redis cache system for django

### DIFF
--- a/src-django/requirements.txt
+++ b/src-django/requirements.txt
@@ -7,6 +7,7 @@ django-compressor==2.0
 django-cors-headers==1.1.0
 django-filter==0.12.0
 django-nose==1.4.3
+django-redis-cache==1.6.5
 djangorestframework==3.3.2
 djangorestframework-recursive==0.1.1
 django-extensions==1.6.1
@@ -16,3 +17,4 @@ gunicorn==19.4.5
 nose==1.3.7
 psycopg2==2.6.1
 redis==2.10.3
+

--- a/src-django/sanaprotocolbuilder/settings.py
+++ b/src-django/sanaprotocolbuilder/settings.py
@@ -75,6 +75,13 @@ ROOT_URLCONF = 'sanaprotocolbuilder.urls'
 
 WSGI_APPLICATION = 'sanaprotocolbuilder.wsgi.application'
 
+CACHES = {
+    'default': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': 'localhost:6379',
+    },
+}
+
 # ------------------------------------------------------------------------------
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases


### PR DESCRIPTION
This allows us to connect to redis using the internal django cache libraries. Redis is already running for Celery, this allows us to connect to it via django's internal caching system. We can use:

`from django.core.cache import cache` and then use redis library functions like `set` and `get`

And then, when we want to test functionality, we can use django's `@override_settings` or `@modify_settings`

```
@modify_settings(CACHES={
        'default': 'django.core.cache.backends.locmem.LocMemCache',
})
```

Resolves  #316 