### PR TITLE
Added jinja2 template loader module & template dir

### DIFF
--- a/src-django/mailer/templater.py
+++ b/src-django/mailer/templater.py
@@ -1,0 +1,5 @@
+from jinja2 import Environment, PackageLoader
+
+
+def get_environment(application, template_dir):
+    return Environment(loader=PackageLoader(application, template_dir))


### PR DESCRIPTION
This commit adds a template directory under `api` for storing our jinja templates. The templater module is just to load the template environment. Then, once you have the environment object returned by `get_environment` you can:

Load up your template by name: `template = env.get_template('template_name.html')`
And then you can render it: `template.render(your='variables', go='here')`

So, if we have a template like
```
Hello {{ name }},  I'm {{ sender }}.
```

we can render the template like this: `template.render(name='Geoff', sender='Lenny')`

and we'll get `Hello Geoff, I'm Lenny`

Resolves #317