### PR TITLE
Properly get and use the user's name

### DIFF
--- a/src-backbone/app/js/models/procedure.js
+++ b/src-backbone/app/js/models/procedure.js
@@ -12,10 +12,12 @@ let Procedure = Backbone.Model.extend({
     urlRoot: '/api/procedures',
 
     defaults: function() {
+        let user = App().session.user;
+
         // These values are only used when we POST /procedures a new procedure
         return {
             'title': i18n.t('Untitled Procedure'),
-            'author': i18n.t('No author specified'), // TODO either fetch user's username or let API allow nullable authors
+            'author': user.get('first_name') + ' ' + user.get('last_name'),
         };
     },
 

--- a/src-backbone/app/js/templates/auth/signupView.hbs
+++ b/src-backbone/app/js/templates/auth/signupView.hbs
@@ -1,5 +1,13 @@
 <form>
     <div class="form-group">
+        <label for="first_name" class="sr-only">{{ i18n "First Name" }}</label>
+        <input type="text" class="form-control" id="first_name" name="first_name" placeholder="First Name">
+    </div>
+    <div class="form-group">
+        <label for="last_name" class="sr-only">{{ i18n "Last Name" }}</label>
+        <input type="text" class="form-control" id="last_name" name="last_name" placeholder="Last Name">
+    </div>
+    <div class="form-group">
         <label for="username" class="sr-only">{{ i18n "Username" }}</label>
         <input type="text" class="form-control" id="username" name="username" placeholder="Username">
     </div>

--- a/src-backbone/app/js/views/procedures/proceduresNavbarView.js
+++ b/src-backbone/app/js/views/procedures/proceduresNavbarView.js
@@ -1,4 +1,5 @@
 const EventKeys = require('utils/eventKeys');
+const App = require('utils/sanaAppInstance');
 
 
 module.exports = Marionette.LayoutView.extend({
@@ -17,7 +18,9 @@ module.exports = Marionette.LayoutView.extend({
     },
 
     onAttach: function() {
-        const welcomeMessage = i18n.t('Hello username', {username: 'Trinovantes'}); // TODO fetch username from server
+        const welcomeMessage = i18n.t('Hello username', {
+            username: App().session.user.get('first_name')
+        });
 
         // Do this after View is shown so that rootLayoutView can find
         // p.navbar-text inside this View

--- a/src-backbone/app/locales/en/translation.json
+++ b/src-backbone/app/locales/en/translation.json
@@ -150,6 +150,7 @@
 
     // Concepts
     "CSV Imported Successfuly": "CSV Imported Successfuly",
-    "Upload Concept Dictionary": "Upload Concept Dictionary",
+    "Upload Concept Dictionary": "Upload Concept Dictionary"
 
+    //DO NOT PUT A TRALING COMMA AT THE END
 }

--- a/src-backbone/app/locales/en/translation.json
+++ b/src-backbone/app/locales/en/translation.json
@@ -14,6 +14,8 @@
     "Sign up": "Sign up",
     "Already have an account? Log in": "Already have an account? <a href=\"/login\">Log in<\/a>",
     "Language": "Language",
+    "First Name": "First Name",
+    "Last Name": "Last Name",
 
     // Log in
     "Remember Me": "Remember Me",
@@ -28,7 +30,7 @@
     // Account Settings
     "Successfuly updated account details!": "Successfuly updated account details!",
     "There was a problem": "There was a problem",
-    "Password successfully reset!": "Password successfully reset!", 
+    "Password successfully reset!": "Password successfully reset!",
     "Email to reset password sent!": "Email to reset password sent!",
     "Confirm Password": "Confirm Password",
     "New Password": "New Password",

--- a/src-django/authentication/forms.py
+++ b/src-django/authentication/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 
 class SignupForm(UserCreationForm):
     first_name = forms.CharField(required=True, label='First Name', help_text='Your first name', max_length=20)
-    first_name = forms.CharField(required=True, label='Last Name', help_text='Your last name', max_length=20)
+    last_name = forms.CharField(required=True, label='Last Name', help_text='Your last name', max_length=20)
     email = forms.EmailField(required=True, label='Email', help_text='This will be your username when you login')
     accept_tos = forms.BooleanField(required=True, label='I accept the Terms of Service')
 

--- a/src-django/authentication/forms.py
+++ b/src-django/authentication/forms.py
@@ -4,16 +4,20 @@ from django.contrib.auth.models import User
 
 
 class SignupForm(UserCreationForm):
-    email = forms.EmailField(required=True, label="Email", help_text="This will be your username when you login")
-    accept_tos = forms.BooleanField(required=True, label="I accept the Terms of Service")
+    first_name = forms.CharField(required=True, label='First Name', help_text='Your first name', max_length=20)
+    first_name = forms.CharField(required=True, label='Last Name', help_text='Your last name', max_length=20)
+    email = forms.EmailField(required=True, label='Email', help_text='This will be your username when you login')
+    accept_tos = forms.BooleanField(required=True, label='I accept the Terms of Service')
 
     def save(self, commit=True):
         user = super(SignupForm, self).save(commit=False)
         user.email = self.cleaned_data['email']
+        user.first_name = self.cleaned_data['first_name']
+        user.last_name = self.cleaned_data['last_name']
         if commit:
             user.save()
         return user
 
     class Meta:
         model = User
-        fields = ('username', 'email', 'password1', 'password2')
+        fields = ('username', 'email', 'password1', 'password2', 'first_name', 'last_name')

--- a/src-django/authentication/tests/test_signup.py
+++ b/src-django/authentication/tests/test_signup.py
@@ -23,6 +23,8 @@ class SignupTest(TestCase):
     def setUp(self):
         self.client = Client()
         self.valid_fields = {
+            'first_name': 'Foo',
+            'last_name': 'Bar',
             'username': 'admin',
             'email': 'admin@admin.com',
             'password1': 'admin',


### PR DESCRIPTION
Change does two key things

1. Adds first name and last name to the signup form
2. Makes the author field on procedure default to owner's full name if it is blank or non-existent.
3. Fixes the "Hello username" field
4. Fixes translations

Closes #368, #365, #380, #381