### PR TITLE
Add a Marionette region for displaying modals

### DIFF
--- a/src-backbone/app/js/templates/rootLayoutView.hbs
+++ b/src-backbone/app/js/templates/rootLayoutView.hbs
@@ -11,5 +11,6 @@
     </div>
     <div id="navbar-content" class="navbar-collapse collapse"></div>
 </nav>
+<div class="modal fade" id="modal" tabindex="-1"></div>
 <div id="notification-center"></div>
 <div id="main"></div>

--- a/src-backbone/app/js/views/builder/pageDetails/pageElements/modalRegion.js
+++ b/src-backbone/app/js/views/builder/pageDetails/pageElements/modalRegion.js
@@ -1,0 +1,24 @@
+module.exports = Marionette.Region.extend({
+
+    constructor: function() {
+        _.bindAll(this, 'getEl', 'showModal', 'hideModal');
+        Marionette.Region.prototype.constructor.apply(this, arguments);
+        this.on('show', this.showModal, this);
+    },
+
+    getEl: function(selector) {
+        var $el = $(selector);
+        $el.on('hidden', this.close);
+        return $el;
+    },
+
+    showModal: function(view) {
+        view.on('close', this.hideModal, this);
+        this.$el.modal('show');
+    },
+
+    hideModal: function() {
+        this.$el.modal('hide');
+    },
+
+});

--- a/src-backbone/app/js/views/rootLayoutView.js
+++ b/src-backbone/app/js/views/rootLayoutView.js
@@ -1,3 +1,4 @@
+const ModalRegion = require('views/builder/pageDetails/pageElements/modalRegion');
 const Notifications = require('collections/notifications');
 const NotificationsCollectionView = require('views/notifications/notificationsCollectionView');
 
@@ -8,13 +9,17 @@ const App = require('utils/sanaAppInstance');
 
 
 module.exports = Marionette.LayoutView.extend({
-  
+
     el: 'body',
 
     template: require('templates/rootLayoutView'),
 
     regions: {
         'navbar': 'nav#navbar div#navbar-content',
+        'modal': {
+            selector: 'div#modal',
+            regionClass: ModalRegion
+        },
         'notificationCenter': 'div#notification-center',
         'main': 'div#main',
     },


### PR DESCRIPTION
This is a part of my work on a concept picker, but @Ommy needs it now.

I will eventually make a `ModalLayoutView` to abstract the Bootstrap HTML mechanics, but I just wanted to get this out ASAP.

Here's the rundown:

1. Make a new template and view for the contents of the modal — the template must conform to the Bootstrap convention for modals (but the view does not need to be a `LayoutView` as shown below):

    ```html
    <!-- app/js/templates/.../someModalView.hbs -->
    <div class="modal-dialog">
        <div class="modal-content">
            <div class="modal-header">
                <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
                <h4 class="modal-title">{{ i18n "Modal Title" }}</h4>
            </div>
            <div class="modal-body">
                ...
            </div>
        </div>
    </div>
    ```

    ```javascript
    // app/js/views/.../someView.js
    module.exports = Marionette.LayoutView.extend({

            template: require('templates/.../someModalView'),

    });
    ```

2. Render the view into the modal:

    ```javascript
    // app/js/views/.../someView.js
    const App = require('utils/sanaAppInstance');
    const SomeModalView = require('views/.../someModalView');

    ...

    _onSomeEvent: function(event) {
        App().RootView.modal.show(new SomeModalView());
    },
    ```