### PR TITLE
Cleanup Styling

### DIFF
--- a/src-backbone/app/css/modules/auth.less
+++ b/src-backbone/app/css/modules/auth.less
@@ -8,7 +8,7 @@ h1.auth-page-logo{
     font-size: 24px;
     font-weight: bold;
     line-height: 40px;
-    margin: (@icon-size + @offset-from-heading + 120px) 0 60px;
+    margin: (@icon-size + @offset-from-heading + 50px) 0 50px;
     position: relative;
     text-align: center;
 
@@ -35,7 +35,7 @@ div#auth-form-area{
 
     div.footnote{
         color: @grey-text;
-        margin: 60px 0;
+        margin: 25px 0 50px;
         text-align: center;
     }
 }

--- a/src-backbone/app/css/modules/procedures.less
+++ b/src-backbone/app/css/modules/procedures.less
@@ -4,8 +4,6 @@
 header#procedures-menu{
     box-shadow: 0 0 20px hsla(0, 0, 40%, 0.2);
     overflow: hidden;
-    padding-top: 30px;
-    padding-bottom: 30px;
 
     h1{
         background-image: url('/img/logo.png');

--- a/src-backbone/app/css/modules/procedures.less
+++ b/src-backbone/app/css/modules/procedures.less
@@ -75,7 +75,7 @@ header#procedures-list-heading{
 
     h2,
     a#new-procedure-btn{
-        margin: 60px 0;
+        margin: 30px 0;
     }
 
     h2{

--- a/src-backbone/app/js/templates/procedures/proceduresLayoutView.hbs
+++ b/src-backbone/app/js/templates/procedures/proceduresLayoutView.hbs
@@ -3,7 +3,6 @@
     <ul>
         <li><a href="/{{ currentLanguage }}/procedures">{{ i18n "Procedures" }}</a></li>
         <li><a href="/{{ currentLanguage }}/concepts">{{ i18n "Concepts" }}</a></li>
-        <li><a href="/{{ currentLanguage }}/help">{{ i18n "Help" }}</a></li>
     </ul>
 </header>
 

--- a/src-backbone/app/js/templates/procedures/proceduresLayoutView.hbs
+++ b/src-backbone/app/js/templates/procedures/proceduresLayoutView.hbs
@@ -1,9 +1,5 @@
 <header class="container-fluid spb-container" id="procedures-menu">
     <h1>{{ i18n "Sana Protocol Builder" }}</h1>
-    <ul>
-        <li><a href="/{{ currentLanguage }}/procedures">{{ i18n "Procedures" }}</a></li>
-        <li><a href="/{{ currentLanguage }}/concepts">{{ i18n "Concepts" }}</a></li>
-    </ul>
 </header>
 
 <div class="container">


### PR DESCRIPTION
Reduce margins and padding on the auth and procedures page so they fit properly on smaller screens. More emphasis on the content, rather than headers.

<img width="1280" alt="screen shot 2016-03-05 at 6 45 03 pm" src="https://cloud.githubusercontent.com/assets/995382/13551296/876e7a36-e302-11e5-8e36-c7a51cc1292e.png">
<img width="1280" alt="screen shot 2016-03-05 at 6 45 13 pm" src="https://cloud.githubusercontent.com/assets/995382/13551298/91a724bc-e302-11e5-9c01-be54b1e0a283.png">
<img width="1280" alt="screen shot 2016-03-05 at 6 45 25 pm" src="https://cloud.githubusercontent.com/assets/995382/13551299/936a6d2c-e302-11e5-8a1e-51ce90b36ba3.png">



Closes #372, #374