### PR TITLE
Explicitly make all foreign key deletes cascade

### DIFF
--- a/src-django/api/models.py
+++ b/src-django/api/models.py
@@ -8,7 +8,7 @@ class Procedure(models.Model):
     title = models.CharField(max_length=255, blank=True)
     author = models.CharField(max_length=255, blank=True)
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)
-    owner = models.ForeignKey(User)
+    owner = models.ForeignKey(User, on_delete=models.CASCADE)
     last_modified = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True)
 
@@ -18,7 +18,7 @@ class Procedure(models.Model):
 
 class Page(models.Model):
     display_index = models.PositiveIntegerField()
-    procedure = models.ForeignKey(Procedure, related_name='pages')
+    procedure = models.ForeignKey(Procedure, related_name='pages', on_delete=models.CASCADE)
     last_modified = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True)
 
@@ -98,7 +98,7 @@ class Element(models.Model):
     action = models.TextField(null=True, blank=True)
     mime_type = models.CharField(max_length=128, null=True, blank=True)
 
-    page = models.ForeignKey(Page, related_name='elements')
+    page = models.ForeignKey(Page, related_name='elements', on_delete=models.CASCADE)
     last_modified = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True)
 
@@ -130,7 +130,7 @@ class ShowIf(models.Model):
         'LESS'
     )
 
-    page = models.ForeignKey(Page, related_name='show_if')
+    page = models.ForeignKey(Page, related_name='show_if', on_delete=models.CASCADE)
     last_modified = models.DateTimeField(auto_now=True)
     created = models.DateTimeField(auto_now_add=True)
     conditions = models.TextField()

--- a/src-django/api/tests/test_model_procedure.py
+++ b/src-django/api/tests/test_model_procedure.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.db import IntegrityError
-from nose.tools import raises, assert_equals, assert_true, assert_is_not_none
-from api.models import Procedure
+from nose.tools import raises, assert_equals, assert_true, assert_is_not_none, assert_raises
+from api.models import Procedure, Page, Element, ShowIf
 from utils import factories
 
 
@@ -66,3 +66,29 @@ class ProcedureTest(TestCase):
         )
 
         assert_true(original_last_modified < procedure.last_modified)
+
+    def test_cascade_delete(self):
+        procedure = factories.ProcedureFactory()
+        page = factories.PageFactory(
+            procedure=procedure
+        )
+        element = factories.ElementFactory(
+            page=page
+        )
+        show_if = factories.ShowIfFactory(
+            page=page
+        )
+
+        procedure.delete()
+
+        with assert_raises(Procedure.DoesNotExist):
+            Procedure.objects.get(pk=procedure.pk)
+
+        with assert_raises(Page.DoesNotExist):
+            Page.objects.get(pk=page.pk)
+
+        with assert_raises(Element.DoesNotExist):
+            Element.objects.get(pk=element.pk)
+
+        with assert_raises(ShowIf.DoesNotExist):
+            ShowIf.objects.get(pk=show_if.pk)


### PR DESCRIPTION
It defaults to this, but better for my piece of mind and it becomes mandatory to do this in Django 2.0