### PR TITLE
Add a check for empty responses in parse functions

### DIFF
--- a/src-backbone/app/js/models/concept.js
+++ b/src-backbone/app/js/models/concept.js
@@ -3,8 +3,13 @@ module.exports = Backbone.Model.extend({
     urlRoot: '/api/concepts',
 
     parse: function(response, options) {
-        response.created       = new Date(Date.parse(response.created));
-        response.last_modified = new Date(Date.parse(response.last_modified));
+        if (_.has(response, 'created')) {
+            response.created = new Date(Date.parse(response.created));
+        }
+
+        if (_.has(response, 'last_modified')) {
+            response.last_modified = new Date(Date.parse(response.last_modified));
+        }
 
         return response;
     },

--- a/src-backbone/app/js/models/element.js
+++ b/src-backbone/app/js/models/element.js
@@ -34,8 +34,13 @@ module.exports = Backbone.Model.extend({
     },
 
     parse: function(response, options) {
-        response.created = new Date(Date.parse(response.created));
-        response.last_modified = new Date(Date.parse(response.last_modified));
+        if (_.has(response, 'created')) {
+            response.created = new Date(Date.parse(response.created));
+        }
+
+        if (_.has(response, 'last_modified')) {
+            response.last_modified = new Date(Date.parse(response.last_modified));
+        }
 
         if (this.isChoiceBased(response.element_type)) {
             this.choices.setChoices(response.choices, response.answer);

--- a/src-backbone/app/js/models/page.js
+++ b/src-backbone/app/js/models/page.js
@@ -81,8 +81,13 @@ module.exports = Backbone.Model.extend({
     },
 
     parse: function(response, options) {
-        response.created = new Date(Date.parse(response.created));
-        response.last_modified = new Date(Date.parse(response.last_modified));
+        if (_.has(response, 'created')) {
+            response.created = new Date(Date.parse(response.created));
+        }
+
+        if (_.has(response, 'last_modified')) {
+            response.last_modified = new Date(Date.parse(response.last_modified));
+        }
 
         this.elements.reset(response.elements, { parse: true });
         delete response.elements;

--- a/src-backbone/app/js/models/procedure.js
+++ b/src-backbone/app/js/models/procedure.js
@@ -48,8 +48,13 @@ let Procedure = Backbone.Model.extend({
     },
 
     parse: function(response, options) {
-        response.created       = new Date(Date.parse(response.created));
-        response.last_modified = new Date(Date.parse(response.last_modified));
+        if (_.has(response, 'created')) {
+            response.created = new Date(Date.parse(response.created));
+        }
+
+        if (_.has(response, 'last_modified')) {
+            response.last_modified = new Date(Date.parse(response.last_modified));
+        }
 
         this._setPages(response.pages);
         delete response.pages;


### PR DESCRIPTION
For some reason, only in Safari, `parse` is called with an empty response and then subsequently called with the populated response. This caused errors to be thrown, so I added a check for an early return.

EDIT: Looks like this is more complicated, let's hold off for now.