### PR TITLE
Add empty views for Concept and Subroutine modals

### DIFF
--- a/src-backbone/app/css/modules/builderPageDetails.less
+++ b/src-backbone/app/css/modules/builderPageDetails.less
@@ -45,6 +45,15 @@ section#concept-table {
 
         }
     }
+
+    .empty-concepts {
+        text-align: center;
+
+        .no-concepts-found {
+            margin-bottom: 16px;
+            font-size: 20px;
+        }
+    }
 }
 
 section#subroutine-table {
@@ -67,6 +76,15 @@ section#subroutine-table {
                 }
             }
 
+        }
+    }
+
+    .empty-subroutines {
+        text-align: center;
+
+        .no-subroutines-found {
+            margin-bottom: 16px;
+            font-size: 20px;
         }
     }
 }

--- a/src-backbone/app/js/templates/builder/pageDetails/pageElements/concepts/conceptCollectionEmptyView.hbs
+++ b/src-backbone/app/js/templates/builder/pageDetails/pageElements/concepts/conceptCollectionEmptyView.hbs
@@ -1,0 +1,5 @@
+<div class="no-concepts-found">{{ i18n "No concepts found" }}</div>
+
+{{#if canUseConceptsManager }}
+    <a id="concepts-manager-btn" class="btn btn-success" href="/{{ currentLanguage }}/concepts/manager">{{ i18n "Concepts Manager" }}</a>
+{{/if}}

--- a/src-backbone/app/js/templates/builder/pageDetails/pageElements/subroutines/subroutineCollectionEmptyView.hbs
+++ b/src-backbone/app/js/templates/builder/pageDetails/pageElements/subroutines/subroutineCollectionEmptyView.hbs
@@ -1,0 +1,5 @@
+<div class="no-subroutines-found">{{ i18n "No subroutines found" }}</div>
+
+{{#if canUseSubroutinesManager }}
+    <a id="subroutines-manager-btn" class="btn btn-success" href="/{{ currentLanguage }}/subroutines">{{ i18n "Subroutines Manager" }}</a>
+{{/if}}

--- a/src-backbone/app/js/views/builder/pageDetails/pageElements/concepts/conceptCollectionEmptyView.js
+++ b/src-backbone/app/js/views/builder/pageDetails/pageElements/concepts/conceptCollectionEmptyView.js
@@ -1,0 +1,15 @@
+const App = require('utils/sanaAppInstance');
+
+module.exports = Marionette.ItemView.extend({
+
+    template: require('templates/builder/pageDetails/pageElements/concepts/conceptCollectionEmptyView'),
+    tagName: 'div',
+    className: 'empty-concepts',
+
+    templateHelpers: function() {
+        return {
+            canUseConceptsManager: App().session.user.isPriveleged(),
+        };
+    },
+
+});

--- a/src-backbone/app/js/views/builder/pageDetails/pageElements/concepts/conceptCollectionView.js
+++ b/src-backbone/app/js/views/builder/pageDetails/pageElements/concepts/conceptCollectionView.js
@@ -4,6 +4,8 @@ module.exports = Marionette.CollectionView.extend({
 
     childView: require('./conceptListItemView'),
 
+    emptyView: require('./conceptCollectionEmptyView'),
+
     initialize: function(options) {
         this.page = options.page;
     },

--- a/src-backbone/app/js/views/builder/pageDetails/pageElements/subroutines/subroutineCollectionEmptyView.js
+++ b/src-backbone/app/js/views/builder/pageDetails/pageElements/subroutines/subroutineCollectionEmptyView.js
@@ -1,0 +1,15 @@
+const App = require('utils/sanaAppInstance');
+
+module.exports = Marionette.ItemView.extend({
+
+    template: require('templates/builder/pageDetails/pageElements/subroutines/subroutineCollectionEmptyView'),
+    tagName: 'div',
+    className: 'empty-subroutines',
+
+    templateHelpers: function() {
+        return {
+            canUseSubroutinesManager: App().session.user.isPriveleged(),
+        };
+    },
+
+});

--- a/src-backbone/app/js/views/builder/pageDetails/pageElements/subroutines/subroutineCollectionView.js
+++ b/src-backbone/app/js/views/builder/pageDetails/pageElements/subroutines/subroutineCollectionView.js
@@ -4,6 +4,8 @@ module.exports = Marionette.CollectionView.extend({
 
     childView: require('./subroutineListItemView'),
 
+    emptyView: require('./subroutineCollectionEmptyView'),
+
     initialize: function(options) {
         this.page = options.page;
     },


### PR DESCRIPTION
Previously when a user had no Concepts or Subroutines available, an empty search bar was shown in the respective modal. This PR adds emptyViews for these elements that:

1. Indicate that there are no Concepts/Subroutines.
2. Provide a link to the Concept/Subroutine manager if the user has sufficient privileges.

Screenshots:
Concepts modal with items:
![conceptlistfull](https://user-images.githubusercontent.com/10334328/45270755-b2377980-b455-11e8-847e-407a6a312dad.png)

Empty concepts modal (user can access Concepts Manager):
![conceptlistemptypriviledged](https://user-images.githubusercontent.com/10334328/45270762-b9f71e00-b455-11e8-94df-bf8522fb574f.png)

Empty concepts modal (user cannot access Concepts Manager):
![conceptlistempty](https://user-images.githubusercontent.com/10334328/45270763-c11e2c00-b455-11e8-89cf-3d0e29c9b3fc.png)

Likewise, for Subroutines:
Empty Subroutines modal (user can access Subroutines Manager):
![subroutinesemptypriviledge](https://user-images.githubusercontent.com/10334328/45270766-c9766700-b455-11e8-8387-c8292252f004.png)

Empty Subroutines modal (user cannot access Subroutines Manager):
![subroutineslistempty](https://user-images.githubusercontent.com/10334328/45270770-d4c99280-b455-11e8-9188-8c8777e4bb23.png)
