### PR TITLE
Add subroutines router stub to JS tests

### DIFF
--- a/src-backbone/test/unit/auth/authController_test.js
+++ b/src-backbone/test/unit/auth/authController_test.js
@@ -49,6 +49,7 @@ describe('Auth Controller', function() {
             'routers/infoRouter': {},
             'routers/proceduresRouter': {},
             'routers/conceptsRouter': {},
+            'routers/subroutinesRouter': {},
             'utils/helpers': helpers,
         });
         app = new SanaApp();

--- a/src-backbone/test/unit/auth/loginView_test.js
+++ b/src-backbone/test/unit/auth/loginView_test.js
@@ -14,6 +14,7 @@ describe("Login View", function () {
             'routers/infoRouter': {},
             'routers/proceduresRouter': {},
             'routers/conceptsRouter': {},
+            'routers/subroutinesRouter': {},
             'utils/helpers': {},
         });
         app = new SanaApp();

--- a/src-backbone/test/unit/auth/signupView_test.js
+++ b/src-backbone/test/unit/auth/signupView_test.js
@@ -14,6 +14,7 @@ describe("Signup View", function () {
             'routers/infoRouter': {},
             'routers/proceduresRouter': {},
             'routers/conceptsRouter': {},
+            'routers/subroutinesRouter': {},
             'utils/helpers': {},
         });
         app = new SanaApp();

--- a/src-backbone/test/unit/sanaApp_test.js
+++ b/src-backbone/test/unit/sanaApp_test.js
@@ -19,6 +19,7 @@ describe('SanaApp', function() {
                 'routers/infoRouter': {},
                 'routers/proceduresRouter': {},
                 'routers/conceptsRouter': {},
+                'routers/subroutinesRouter': {},
                 'utils/helpers': helpers,
             });
             app = new SanaApp();
@@ -72,6 +73,7 @@ describe('SanaApp', function() {
                 'routers/infoRouter': {},
                 'routers/proceduresRouter': {},
                 'routers/conceptsRouter': {},
+                'routers/subroutinesRouter': {},
                 'utils/helpers': {},
             });
             app = new SanaApp();


### PR DESCRIPTION
Some JS tests were failing after subroutines were added because the subroutines router was not properly stubbed. This adds the appropriate stubbing, and I confirmed that all JS tests now pass with gulp test.