### PR TITLE
Raise exception if user tries to generate an unowned procedure.

### DIFF
--- a/src-django/api/generator.py
+++ b/src-django/api/generator.py
@@ -291,9 +291,8 @@ class ProtocolBuilder:
         except Procedure.DoesNotExist:
             raise ValueError('Invalid procedure id')
 
-        # TODO Security issue: Allow any user (even unauthenticated) to access any procedure
-        # if procedure.owner != owner:
-        #     raise ValueError('Invalid owner')
+        if procedure.owner != owner:
+            raise ValueError('Invalid owner')
 
         procedure_etree_element = ProcedureGenerator(procedure).generate()
 

--- a/src-django/api/views.py
+++ b/src-django/api/views.py
@@ -2,7 +2,6 @@ from django.http import HttpResponse, JsonResponse, HttpResponseBadRequest
 from rest_framework import viewsets, status, filters, mixins
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route, list_route
-from rest_framework.permissions import AllowAny
 from django.contrib.auth.models import User
 from django.db.utils import DatabaseError
 from postgres_copy import CopyMapping


### PR DESCRIPTION
Procedures used to have a different permission model where they could be accessed by users that were not their owner. This is no longer the case, so users should not be able to generate a procedure they do not own.