### PR TITLE
Fix test_element_has_version_attrib to actually read version.

### DIFF
--- a/src-django/api/tests/test_generator.py
+++ b/src-django/api/tests/test_generator.py
@@ -61,7 +61,7 @@ class ProcedureGeneratorTest(TestCase):
 
     def test_element_has_version_attrib(self):
         assert_true('version' in self.procedure_etree_element.attrib)
-        assert_equals(self.procedure_etree_element.attrib['version'], str(self.procedure.last_modified))
+        assert_equals(self.procedure_etree_element.attrib['version'], str(self.procedure.version))
 
     def test_element_has_uuid_attrib(self):
         assert_true('uuid' in self.procedure_etree_element.attrib)


### PR DESCRIPTION
Fixes a mistake in https://github.com/SanaMobile/sana.protocol_builder/commit/731e0598088c427daa08d339a651f91f09af9269 that broke a test.