### PR TITLE
Make concepts optional

### DIFF
--- a/src-django/api/generator.py
+++ b/src-django/api/generator.py
@@ -53,9 +53,6 @@ class ElementGenerator:
         self.name = 'Element'
         self.element = element
 
-        if not self.element.concept:
-            raise_error_on_page('Element has no concept', self.element.page)
-
         if not self.element.question:
             raise_error_on_page('Element has no question', self.element.page)
 
@@ -76,10 +73,12 @@ class ElementGenerator:
         props = {
             'type': self.element.element_type,
             'id': str(self.element.pk),
-            'concept': self.element.concept.name,
             'question': self.element.question,
             'answer': self.__parse_answers()
         }
+
+        if self.element.concept:
+            props['concept'] = self.element.concept.name
 
         if self.element.required:
             props['required'] = str(self.element.required).lower()
@@ -119,9 +118,6 @@ class AbstractElementGenerator:
         self.name = 'AbstractElement'
         self.element = element
 
-        if not self.element.concept:
-            raise_error_on_page('Element has no concept', self.element.page)
-
         if not self.element.question:
             raise_error_on_page('Element has no question', self.element.page)
 
@@ -142,10 +138,12 @@ class AbstractElementGenerator:
         props = {
             'type': self.element.element_type,
             'id': str(self.element.pk),
-            'concept': self.element.concept.name,
             'question': self.element.question,
             'answer': self.__parse_answers()
         }
+
+        if self.element.concept:
+            props['concept'] = self.element.concept.name
 
         if self.element.required:
             props['required'] = str(self.element.required).lower()

--- a/src-django/api/tests/test_generator.py
+++ b/src-django/api/tests/test_generator.py
@@ -124,13 +124,13 @@ class ElementGeneratorTest(TestCase):
         assert_true('concept' in self.attribs)
         assert_equals(self.attribs['concept'], self.element.concept.name)
 
-    @raises(ValueError)
-    def test_error_if_no_concept(self):
+    def test_concept_optional(self):
         element = factories.ElementFactory(
             concept=None
         )
 
-        generators.ElementGenerator(element).generate(ElementTree.Element('test'))
+        element_etree = generators.ElementGenerator(element).generate(ElementTree.Element('test'))
+        assert_false('concept' in element_etree.attrib)
 
     def test_element_has_question(self):
         assert_true('question' in self.attribs)


### PR DESCRIPTION
Elements do not have a concept by default. While concepts can be useful for organizing large procedures, requiring every element to have a concept in order for a procedure to be generated seems like a mistake.